### PR TITLE
Update aws libs & release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0
+* Update _aws-sdk-dynamodb_ to `0.22`.
+
 ## 0.9.0
 * Update _aws-sdk-dynamodb_ to `0.21`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynamodb-lease"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Alex Butler <alexheretic@gmail.com>"]
 edition = "2021"
 description = "Dynamodb distributed lock client"
@@ -11,14 +11,14 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.57"
-aws-sdk-dynamodb = { version = "0.21", default-features = false, features = ["rt-tokio"] }
+aws-sdk-dynamodb = { version = "0.22", default-features = false, features = ["rt-tokio"] }
 time = "0.3.9"
 tokio = { version = "1.18", features = ["macros"] }
 tracing = "0.1.35"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-aws-config = "0.51"
+aws-config = "0.52"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [features]


### PR DESCRIPTION
Update _aws-sdk-dynamodb_ to `0.22` & release `0.10.0`.

cargo publish is currently a manual step that I can (still) do or someone at truelayer can do, let me know if you have a preference.